### PR TITLE
Bug Fix iPhone Slider Overlap

### DIFF
--- a/src/watch/hearRingiOSWatchOS/hearRingiOSWatchOS WatchKit Extension/Settings/SettingsView.swift
+++ b/src/watch/hearRingiOSWatchOS/hearRingiOSWatchOS WatchKit Extension/Settings/SettingsView.swift
@@ -35,6 +35,7 @@ struct SettingsView: View{
                     newThreshold in slidercontroller.sliderChanged(value: newThreshold, slider: sliders.high, lowThreshold: weakValue)
                 }
         }
+        // Do NOT pull thresholdBuffer from connectivity
         .onAppear{
             settings = controller.getSettings()
             weakValue = shared.SettingsChanged.weakValue

--- a/src/watch/hearRingiOSWatchOS/hearRingiOSWatchOS/SettingsView.swift
+++ b/src/watch/hearRingiOSWatchOS/hearRingiOSWatchOS/SettingsView.swift
@@ -11,11 +11,9 @@ import CoreData
 
 struct SettingsView: View {
     @Environment(\.managedObjectContext) var moc
-    
-    
-    @State var weakerValue: Double = 50
-    @State var strongerValue: Double = 90
-    @State var separatorValue: Double = 10
+    @State var weakValue: Double = 50.0
+    @State var strongValue: Double = 90.0
+    @State var thresholdBuffer: Double = 10.0
     @StateObject var shared = Connectivity.shared
     @StateObject var controller = DataController()
     @StateObject var slidercontroller = SettingsSliderController()
@@ -28,13 +26,13 @@ struct SettingsView: View {
                     // Weak Vibration Slider
                     Text("Weak Vibration Threshold")
                         .font(.body)
-                    Slider(value: $weakerValue, in: 0.0...strongerValue-separatorValue)
+                    Slider(value: $weakValue, in: 0.0...strongValue-thresholdBuffer)
                         .accentColor(.yellow)
                         .padding()
-                        .onChange(of: weakerValue){
-                            newThreshold in slidercontroller.sliderChanged(value: newThreshold, slider: sliders.low, highThreshold: strongerValue)
+                        .onChange(of: weakValue){
+                            newThreshold in slidercontroller.sliderChanged(value: newThreshold, slider: sliders.low, highThreshold: strongValue)
                         }
-                    Text("\(weakerValue, specifier: "%.1f") Decibels")
+                    Text("\(weakValue, specifier: "%.1f") Decibels")
                         .font(.subheadline)
                     
                     Divider()
@@ -43,24 +41,30 @@ struct SettingsView: View {
                     // Strong Vibration Slider
                     Text("Strong Vibration Threshold")
                         .font(.body)
-                    Slider(value: $strongerValue, in: weakerValue+separatorValue...120.0)
+                    Slider(value: $strongValue, in: weakValue+thresholdBuffer...120.0)
                         .accentColor(.red)
                         .padding()
-                        .onChange(of: strongerValue){
-                            newThreshold in slidercontroller.sliderChanged(value: newThreshold, slider: sliders.high, lowThreshold: weakerValue)
+                        .onChange(of: strongValue){
+                            newThreshold in slidercontroller.sliderChanged(value: newThreshold, slider: sliders.high, lowThreshold: weakValue)
                         }
-                    Text("\(strongerValue, specifier: "%.1f") Decibels")
+                    Text("\(strongValue, specifier: "%.1f") Decibels")
                         .font(.subheadline)
                 }
             .navigationTitle("Settings")
             }
         }
+        // Do NOT pull thresholdBuffer from connectivity
         .onAppear() {
             Connectivity.shared.SendFirst()
             settings = controller.getSettings()
-            weakerValue = shared.SettingsChanged.weakValue
-            strongerValue = shared.SettingsChanged.strongValue
-            separatorValue = shared.SettingsChanged.bufferValue
+            weakValue = shared.SettingsChanged.weakValue
+            strongValue = shared.SettingsChanged.strongValue
         }
+    }
+}
+
+struct SettingsView_Previews: PreviewProvider {
+    static var previews: some View {
+        SettingsView()
     }
 }


### PR DESCRIPTION
Fixed sliders on iPhone such that they no longer overlap. Included a comment on both SettngsView pages to ensure no one recreates this issue in the future by accident. SettingsView on iPhone now closer resembles Apple Watch.